### PR TITLE
Added 'version' command for 'kyt-cli' and 'kyt-api-server'

### DIFF
--- a/kyt-api-server/Dockerfile
+++ b/kyt-api-server/Dockerfile
@@ -14,7 +14,8 @@ COPY --from=openapi_gen /openapi_gen/* ./openapi_gen/
 
 ENV CGO_ENABLED=0
 ENV GOPATH=/go
-RUN make BIN_DIR=/install OPENAPI_GEN_DIR=./openapi_gen
+ARG VERSION=dev
+RUN VERSION=${VERSION} make BIN_DIR=/install OPENAPI_GEN_DIR=./openapi_gen
 
 FROM scratch
 ENV GIN_MODE=release

--- a/kyt-api-server/Makefile
+++ b/kyt-api-server/Makefile
@@ -1,9 +1,11 @@
 BIN_DIR ?= ../bin
 OPENAPI_GEN_DIR ?= openapi_gen
+VERSION ?= $(shell git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
+GO_LDFLAGS = -ldflags "-X github.com/ci4rail/kyt-cli/kyt-api-server/cmd.version=$(VERSION)"
 
 build:
 	cp ${OPENAPI_GEN_DIR}/model_*.go openapi
-	GOOS=linux GOARCH=386 go build -o ${BIN_DIR}/kyt-api-server main.go
+	GOOS=linux GOARCH=386 go build $(GO_LDFLAGS) -o ${BIN_DIR}/kyt-api-server main.go
 
 clean:
 	rm -f ${BIN_DIR}/kyt-api-server

--- a/kyt-api-server/cmd/version.go
+++ b/kyt-api-server/cmd/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information and quit. Default is false.",
+	Long:  `This command displays version information for the kyt-api-server.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("kyt-api-server %s\n", version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/kyt-api-server/cmd/version.go
+++ b/kyt-api-server/cmd/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021 Ci4Rail GmbH <engineering@ci4rail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kyt-api-server/cmd/version.go
+++ b/kyt-api-server/cmd/version.go
@@ -26,7 +26,7 @@ var version = "dev"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print version information and quit. Default is false.",
+	Short: "Print version information and quit.",
 	Long:  `This command displays version information for the kyt-api-server.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("kyt-api-server %s\n", version)

--- a/kyt-api-server/dobi.yaml
+++ b/kyt-api-server/dobi.yaml
@@ -48,6 +48,7 @@ job=build-kyt-api-server:
     - bin/kyt-api-server
   user: "{user.uid}:{user.gid}"
   env:
+    - VERSION={env.GitVersion_InformationalVersion}
     - BIN_DIR=/install
     - GOCACHE=/tmp/cache
   annotations:
@@ -60,6 +61,8 @@ image=image-kyt-api-server:
   context: "."
   dockerfile: kyt-api-server/Dockerfile
   tags:
-    - "{env.GitVersion_BranchVersion}"
+    - "{env.GitVersion_InformationalVersion}"
+  args:
+    VERSION: "{env.GitVersion_InformationalVersion}"
   annotations:
     description: "-> build kyt-api-server docker image"

--- a/kyt-api-server/dobi.yaml
+++ b/kyt-api-server/dobi.yaml
@@ -26,7 +26,7 @@ job=generate-server-sources:
   sources:
     - kyt-api-spec/kytapi.yaml
   artifact:
-    - kyt-api-server/openapi/routers.go
+    - kyt-api-server/openapi_gen/routers.go
   user: "{user.uid}:{user.gid}"
   annotations:
     description: "-> generate kyt-api-server sources"

--- a/kyt-api-server/main.go
+++ b/kyt-api-server/main.go
@@ -10,7 +10,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -22,11 +21,18 @@ const (
 )
 
 func main() {
-	envName := fmt.Sprintf(envIotHubConnectionsString)
-	_, ok := os.LookupEnv(envName)
+	versionArgFound := false
+	for _, v := range os.Args {
+		if v == "version" || v == "help" || v == "--help" || v == "-h" {
+			versionArgFound = true
+		}
+	}
+	if !versionArgFound {
+		_, ok := os.LookupEnv(envIotHubConnectionsString)
 
-	if !ok {
-		log.Fatalf("Error: environment variable %s missing", envIotHubConnectionsString)
+		if !ok {
+			log.Fatalf("Error: environment variable %s missing", envIotHubConnectionsString)
+		}
 	}
 	cmd.Execute()
 }

--- a/kyt-cli/Makefile
+++ b/kyt-cli/Makefile
@@ -1,8 +1,10 @@
 BIN_DIR ?= ../bin
+VERSION ?= $(shell git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
+GO_LDFLAGS = -ldflags "-X github.com/ci4rail/kyt-cli/kyt-cli/cmd.version=$(VERSION)"
 
 build:
-	GOOS=linux GOARCH=386 go build -o ${BIN_DIR}/kyt main.go
-	GOOS=windows GOARCH=386 go build -o ${BIN_DIR}/kyt.exe main.go
+	GOOS=linux GOARCH=386 go build $(GO_LDFLAGS) -o ${BIN_DIR}/kyt main.go
+	GOOS=windows GOARCH=386 go build $(GO_LDFLAGS) -o ${BIN_DIR}/kyt.exe main.go
 
 clean:
 	rm -rf ${BIN_DIR}/kyt ${BIN_DIR}/kyt.exe

--- a/kyt-cli/cmd/version.go
+++ b/kyt-cli/cmd/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information and quit. Default is false.",
+	Long:  `This command displays version information for the kyt-cli.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("kyt-cli %s\n", version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/kyt-cli/cmd/version.go
+++ b/kyt-cli/cmd/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021 Ci4Rail GmbH <engineering@ci4rail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ var version = "dev"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print version information and quit. Default is false.",
+	Short: "Print version information and quit.",
 	Long:  `This command displays version information for the kyt-cli.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("kyt-cli %s\n", version)

--- a/kyt-cli/dobi.yaml
+++ b/kyt-cli/dobi.yaml
@@ -58,6 +58,7 @@ job=build-kyt-cli:
     - bin/kyt.exe
   user: "{user.uid}:{user.gid}"
   env:
+    - VERSION={env.GitVersion_InformationalVersion}
     - BIN_DIR=/install
     - GOCACHE=/tmp/cache
   annotations:

--- a/kyt-cli/go.sum
+++ b/kyt-cli/go.sum
@@ -54,6 +54,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/ci4rail/kyt-cli v0.0.0-20210113150121-c4a96bdf0943 h1:6VAioo2QZg3g8CQnXZqMdLpVGX9Wth8f/llvxb8IXl0=
 github.com/ci4rail/kyt-cli v0.0.0-20210119080529-0590f7b85039 h1:i2y7EBZbc1564oSkpTIycVsLT4fJPNNM6igDcjDtufc=
+github.com/ci4rail/kyt-cli v0.0.0-20210122071032-9b2326e00117 h1:qc360OLNtwkFRDpVeE1phYdbZdxrBMpJ7MK2tPKAA3Y=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -102,6 +102,7 @@ jobs:
               inputs:
                 - name: source
                 - name: openapi
+                - name: gitversion
               outputs:
                 - name: install
               run:
@@ -112,16 +113,32 @@ jobs:
                     ROOT=$(pwd)
                     cp -r openapi/ ${ROOT}/source/kyt-cli
                     cd ${ROOT}/source/kyt-cli
-                    make
+                    VERSION=$(cat ${ROOT}/gitversion/plain/InformationalVersion) make
                     # copy the artifacts as a
                     cp ../bin/kyt ../bin/kyt.exe ${ROOT}/install
+          - task: generate-build-args-for-image-kyt-api-server
+            image: image-golang
+            config:
+              platform: linux
+              inputs:
+                - name: gitversion
+              outputs:
+                - name: kyt-api-server-build-args
+              run:
+                path: /bin/bash
+                args:
+                  - -ec
+                  - |
+                    ROOT=$(pwd)
+                    echo {\"VERSION\":\"$(cat gitversion/plain/InformationalVersion)\"} > kyt-api-server-build-args/build-args
 
-          - put: image-kyt-api-server
-            params:
-              build: source/
-              dockerfile: source/kyt-api-server/Dockerfile
-              latest: false
-              tag_file: gitversion/plain/InformationalVersion
+      - put: image-kyt-api-server
+        params:
+          build: source/
+          dockerfile: source/kyt-api-server/Dockerfile
+          latest: false
+          tag_file: gitversion/plain/InformationalVersion
+          build_args_file: kyt-api-server-build-args/build-args
 
       - put: gh-release
         params:


### PR DESCRIPTION
`kyt-cli` and `kyt-api-server` now have a command called `version`. The version can either be set with `VERSION` as environment variable or generates as a fallback with the command `git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD`

sample outputs:

```bash
$ ./kyt-api-server version
kyt-api-server 2451f45

$ ./kyt version
Using config file: /home/user/kyt-cli.yaml
kyt-cli 2451f45
```