### PR TITLE
Bugfix cli crash with no config present

### DIFF
--- a/kyt-cli/cmd/login.go
+++ b/kyt-cli/cmd/login.go
@@ -17,10 +17,7 @@ limitations under the License.
 package cmd
 
 import (
-	// "fmt"
-
 	"fmt"
-	"log"
 
 	common "github.com/ci4rail/kyt/kyt-cli/internal/common"
 	e "github.com/ci4rail/kyt/kyt-cli/internal/errors"
@@ -47,7 +44,7 @@ func login(cmd *cobra.Command, args []string) {
 
 	u, err := prompt.Run()
 	if err != nil {
-		log.Panicln(err)
+		e.Er(err)
 	}
 	common.Username = u
 
@@ -59,7 +56,7 @@ func login(cmd *cobra.Command, args []string) {
 
 	common.Password, err = prompt.Run()
 	if err != nil {
-		log.Panicln(err)
+		e.Er(err)
 	}
 
 	claims, err := t.GetAccessToken("dlm")

--- a/kyt-cli/cmd/root.go
+++ b/kyt-cli/cmd/root.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	common "github.com/ci4rail/kyt/kyt-cli/internal/common"
 	configuration "github.com/ci4rail/kyt/kyt-cli/internal/configuration"
 	e "github.com/ci4rail/kyt/kyt-cli/internal/errors"
@@ -84,9 +87,12 @@ func initConfig() {
 		// Search config in home directory with name ".kyt-cli" (without extension).
 		viper.AddConfigPath(home)
 		viper.SetConfigName(common.KytCliConfigFile)
-		err = viper.WriteConfigAs(home + "/" + common.KytCliConfigFile + "." + common.KytCliConfigFileType)
-		if err != nil {
-			e.Er(err)
+		configFile := fmt.Sprintf("%s/%s.%s", home, common.KytCliConfigFile, common.KytCliConfigFileType)
+		if _, err := os.Stat(configFile); os.IsNotExist(err) {
+			err = viper.WriteConfigAs(configFile)
+			if err != nil {
+				e.Er(err)
+			}
 		}
 	}
 

--- a/kyt-cli/cmd/root.go
+++ b/kyt-cli/cmd/root.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	common "github.com/ci4rail/kyt/kyt-cli/internal/common"
 	configuration "github.com/ci4rail/kyt/kyt-cli/internal/configuration"
 	e "github.com/ci4rail/kyt/kyt-cli/internal/errors"
@@ -69,8 +67,8 @@ func initConfig() {
 	// priority 1: servers from config file
 	// priority 2: default servers
 	// If a config file is found, read it in.
-	viper.SetDefault("dlmServerURL", configuration.DefaultDlmServer)
-	viper.SetDefault("almServerURL", configuration.DefaultAlmServer)
+	viper.SetDefault("dlm_server_url", configuration.DefaultDlmServer)
+	viper.SetDefault("alm_server_url", configuration.DefaultAlmServer)
 
 	viper.SetConfigType(common.KytCliConfigFileType)
 	if cfgFile != "" {
@@ -86,14 +84,15 @@ func initConfig() {
 		// Search config in home directory with name ".kyt-cli" (without extension).
 		viper.AddConfigPath(home)
 		viper.SetConfigName(common.KytCliConfigFile)
+		err = viper.WriteConfigAs(home + "/" + common.KytCliConfigFile + "." + common.KytCliConfigFileType)
+		if err != nil {
+			e.Er(err)
+		}
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
 
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
-
-	} else {
+	if err := viper.ReadInConfig(); err != nil {
 		e.Er(err)
 	}
 }

--- a/kyt-cli/internal/apply/apply_customer_manifest.go
+++ b/kyt-cli/internal/apply/apply_customer_manifest.go
@@ -29,7 +29,7 @@ import (
 
 // CustomerManifest -
 func CustomerManifest(c openapi.CustomerManifest) {
-	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
+	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("alm_server_url"), viper.GetString("alm_token"))
 	resp, err := apiClient.DeploymentApi.ApplyPut(ctx).CustomerManifest(c).Execute()
 	// 401 mean 'Unauthorized'. Let's try to refresh the token once.
 	if resp.StatusCode == 401 {
@@ -38,7 +38,7 @@ func CustomerManifest(c openapi.CustomerManifest) {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
+		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("alm_server_url"), viper.GetString("alm_token"))
 		resp, err = apiClient.DeploymentApi.ApplyPut(ctx).CustomerManifest(c).Execute()
 		if resp.StatusCode == 401 {
 			e.Er("Unable to refresh access token. Please run `login` command again.\n")
@@ -55,25 +55,3 @@ func CustomerManifest(c openapi.CustomerManifest) {
 		e.Er(fmt.Sprintf("Error calling DeploymentApi.ApplyPut: %v\n", err))
 	}
 }
-
-// func apply_file() {
-// 	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
-// 	runtimes, resp, err := apiClient.AlmApi.
-// 		RuntimesGet(ctx).Execute()
-// 	// 401 mean 'Unauthorized'. Let's try to refresh the token once.
-// 	if resp.StatusCode == 401 {
-// 		err := token.RefreshToken("alm")
-// 		if err != nil {
-// 			fmt.Println(err)
-// 			os.Exit(1)
-// 		}
-// 		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
-// 		runtimes, _, err = apiClient.AlmApi.RuntimesGet(ctx).Execute()
-// 		if err.Error() != "" {
-// 			e.Er(fmt.Sprintf("Error calling AlmApi.RuntimesGet: %v\n", err))
-// 		}
-// 	} else if err.Error() != "" {
-// 		e.Er(fmt.Sprintf("Error calling AlmApi.RuntimesGet: %v\n", err))
-// 	}
-// 	return runtimes, nil
-// }

--- a/kyt-cli/internal/common/common.go
+++ b/kyt-cli/internal/common/common.go
@@ -20,6 +20,7 @@ package common
 var (
 	Username             string
 	Password             string
+	KytConfigPath        string
 	KytCliConfigFile     = ".kyt-cli"
 	KytCliConfigFileType = "yaml"
 )

--- a/kyt-cli/internal/devices/devices.go
+++ b/kyt-cli/internal/devices/devices.go
@@ -47,7 +47,7 @@ func FetchDevices(list []string) []openapi.Device {
 }
 
 func fetchDevicesAll() []openapi.Device {
-	apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlmServerURL"), viper.GetString("dlm_token"))
+	apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlm_server_url"), viper.GetString("dlm_token"))
 	devices, resp, err := apiClient.DeviceApi.DevicesGet(ctx).Execute()
 	// 401 mean 'Unauthorized'. Let's try to refresh the token once.
 	if resp.StatusCode == 401 {
@@ -56,7 +56,7 @@ func fetchDevicesAll() []openapi.Device {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlmServerURL"), viper.GetString("dlm_token"))
+		apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlm_server_url"), viper.GetString("dlm_token"))
 		devices, _, err = apiClient.DeviceApi.DevicesGet(ctx).Execute()
 		if resp.StatusCode == 403 {
 			e.Er("Forbidden\n")
@@ -72,7 +72,7 @@ func fetchDevicesAll() []openapi.Device {
 }
 
 func fetchDevicesByID(deviceID string) (openapi.Device, error) {
-	apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlmServerURL"), viper.GetString("dlm_token"))
+	apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlm_server_url"), viper.GetString("dlm_token"))
 	device, resp, err := apiClient.DeviceApi.DevicesDidGet(ctx, deviceID).Execute()
 	// 401 mean 'Unauthorized'. Let's try to refresh the token once.
 	if resp.StatusCode == 401 {
@@ -81,7 +81,7 @@ func fetchDevicesByID(deviceID string) (openapi.Device, error) {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlmServerURL"), viper.GetString("dlm_token"))
+		apiClient, ctx := api.NewDlmAPIWithToken(viper.GetString("dlm_server_url"), viper.GetString("dlm_token"))
 		device, resp, err = apiClient.DeviceApi.DevicesDidGet(ctx, deviceID).Execute()
 		if resp.StatusCode == 404 {
 			return openapi.Device{}, fmt.Errorf("No device found with deviceID: %s", deviceID)

--- a/kyt-cli/internal/runtimes/runtimes.go
+++ b/kyt-cli/internal/runtimes/runtimes.go
@@ -47,7 +47,7 @@ func FetchRuntimes(list []string) []openapi.Runtime {
 }
 
 func fetchRuntimesAll() []openapi.Runtime {
-	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
+	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("alm_server_url"), viper.GetString("alm_token"))
 	runtimes, resp, err := apiClient.RuntimesApi.RuntimesGet(ctx).Execute()
 	// 401 mean 'Unauthorized'. Let's try to refresh the token once.
 	if resp.StatusCode == 401 {
@@ -56,7 +56,7 @@ func fetchRuntimesAll() []openapi.Runtime {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
+		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("alm_server_url"), viper.GetString("alm_token"))
 		runtimes, _, err = apiClient.RuntimesApi.RuntimesGet(ctx).Execute()
 		if err.Error() != "" {
 			e.Er(fmt.Sprintf("Error calling AlmApi.RuntimesGet: %v\n", err))
@@ -68,7 +68,7 @@ func fetchRuntimesAll() []openapi.Runtime {
 }
 
 func fetchRuntimesByID(runtimeID string) (openapi.Runtime, error) {
-	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
+	apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("alm_server_url"), viper.GetString("alm_token"))
 	runtime, resp, err := apiClient.RuntimesApi.RuntimesRidGet(ctx, runtimeID).Execute()
 	// 401 mean 'Unauthorized'. Let's try to refresh the token once.
 	if resp.StatusCode == 401 {
@@ -77,7 +77,7 @@ func fetchRuntimesByID(runtimeID string) (openapi.Runtime, error) {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("almServerURL"), viper.GetString("alm_token"))
+		apiClient, ctx := api.NewAlmAPIWithToken(viper.GetString("alm_server_url"), viper.GetString("alm_token"))
 		runtime, resp, err = apiClient.RuntimesApi.RuntimesRidGet(ctx, runtimeID).Execute()
 		if resp.StatusCode == 404 {
 			return openapi.Runtime{}, fmt.Errorf("No runtime found with runtimeID: %s", runtimeID)

--- a/kyt-cli/internal/token/token.go
+++ b/kyt-cli/internal/token/token.go
@@ -30,7 +30,6 @@ import (
 	configuration "github.com/ci4rail/kyt/kyt-cli/internal/configuration"
 	e "github.com/ci4rail/kyt/kyt-cli/internal/errors"
 	"github.com/dgrijalva/jwt-go"
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
@@ -250,12 +249,7 @@ func WriteTokensToConfig(token, refreshToken string, ressource string) {
 	viper.Set(ressource+"_token", token)
 	viper.Set(ressource+"_refresh_token", refreshToken)
 
-	home, err := homedir.Dir()
-	if err != nil {
-		e.Er(err)
-	}
-	err = viper.WriteConfigAs(fmt.Sprintf("%s/%s.%s", home, common.KytCliConfigFile, common.KytCliConfigFileType))
-	if err != nil {
+	if err := viper.WriteConfigAs(common.KytConfigPath); err != nil {
 		e.Er(err)
 	}
 }

--- a/kyt-cli/main.go
+++ b/kyt-cli/main.go
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package main
 
-import "github.com/ci4rail/kyt/kyt-cli/cmd"
+import (
+	"github.com/ci4rail/kyt/kyt-cli/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
- fixed crash when ~/.kyt-cli.yaml was not found
- fixed alm and dlm server strings in config file
- removed panics in user/password prompt
- `--config` argument now creates the new config if it not existent.