### PR TITLE
Default route in customer deployment

### DIFF
--- a/kyt-alm-server/internal/deployment/manifest/manifest.go
+++ b/kyt-alm-server/internal/deployment/manifest/manifest.go
@@ -59,7 +59,14 @@ const (
                         "startupOrder": {{ $element.StartupOrder }}
                     }{{ if lt $i (minus1 $n) }},{{ end }}
                     {{ end }}
-                }
+				},
+				"$edgeHub": {
+					"properties.desired.routes.upstream": {
+						"priority": 0,
+						"route": "FROM /messages/* INTO $upstream",
+						"timeToLiveSecs": 7200
+					}
+				}
             }
         }
     }`


### PR DESCRIPTION
This adds a default route in customer deployments that any modules can send events to its IoT Hub. 